### PR TITLE
Potential fix for code scanning alert no. 2: Cross-site scripting

### DIFF
--- a/publish-service/pom.xml
+++ b/publish-service/pom.xml
@@ -15,6 +15,11 @@
     <artifactId>publish-service</artifactId>
     <packaging>war</packaging>
     <dependencies>
+    <dependency>
+    <groupId>org.apache.commons</groupId>
+    <artifactId>commons-text</artifactId>
+    <version>1.13.1</version>
+    </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>

--- a/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/controller/ProducerController.java
+++ b/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/controller/ProducerController.java
@@ -378,14 +378,17 @@ public class ProducerController {
                 bodyJsonOut = parsedTemplates.toString();
                 log.info("Parsed template: " + bodyJsonOut);
             } else {
-                bodyJsonOut = bodyJson.toString();
+                bodyJsonOut = StringEscapeUtils.escapeJson(bodyJson.toString());
             }
             HttpHeaders headers = new HttpHeaders();
             headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
             HttpEntity<String> entity = new HttpEntity<>(bodyJsonOut, headers);
-            String generateUrl = generateURLTemplate.getUrl() + "&failIfMultipleFound=" + failIfMultipleFound
-                    + "&failIfNoneFound=" + failIfNoneFound + "&lookupInExternalERs=" + lookupInExternalERs
-                    + "&lookupLimit=" + lookupLimit + "&okToLeaveOutInvalidOptionalFields=" + okToLeaveOutInvalidOptionalFields;
+            String generateUrl = generateURLTemplate.getUrl() 
+                    + "&failIfMultipleFound=" + StringEscapeUtils.escapeHtml4(String.valueOf(failIfMultipleFound))
+                    + "&failIfNoneFound=" + StringEscapeUtils.escapeHtml4(String.valueOf(failIfNoneFound))
+                    + "&lookupInExternalERs=" + StringEscapeUtils.escapeHtml4(String.valueOf(lookupInExternalERs))
+                    + "&lookupLimit=" + StringEscapeUtils.escapeHtml4(String.valueOf(lookupLimit))
+                    + "&okToLeaveOutInvalidOptionalFields=" + StringEscapeUtils.escapeHtml4(String.valueOf(okToLeaveOutInvalidOptionalFields));
 
             ResponseEntity<String> response = restTemplate.postForEntity(generateUrl,
                     entity, String.class, generateURLTemplate.getMap(msgProtocol, msgType));
@@ -419,9 +422,9 @@ public class ProducerController {
             String responseBody = null;
             String responseMessage = e.getResponseBodyAsString();
             if (bodyJson.isJsonObject()) {
-                responseBody = "[" + responseMessage + "]";
+                responseBody = "[" + StringEscapeUtils.escapeHtml4(responseMessage) + "]";
             } else if (bodyJson.isJsonArray()) {
-                responseBody = responseMessage;
+                responseBody = StringEscapeUtils.escapeHtml4(responseMessage);
             }
             responseEvents = processingValidEvent(responseBody, msgProtocol, userDomain, tag, routingKey);
             return new ResponseEntity<>(responseEvents, HttpStatus.BAD_REQUEST);


### PR DESCRIPTION
Potential fix for [https://github.com/z-sztrom/eiffel-remrem-publish/security/code-scanning/2](https://github.com/z-sztrom/eiffel-remrem-publish/security/code-scanning/2)

To fix the issue, we need to ensure that all user-provided input is properly sanitized or encoded before being used in constructing the `generateUrl` or `bodyJsonOut`. Additionally, any response data that is returned to the client should be sanitized or encoded to prevent XSS.

1. Use a library like `org.apache.commons.text.StringEscapeUtils` to encode user-provided input for safe inclusion in URLs or JSON.
2. Sanitize the `generateUrl` by encoding all user-provided query parameters.
3. Ensure that the `bodyJsonOut` is properly sanitized or validated before sending it in the HTTP request.
4. Sanitize the response body (`responseBody`) before returning it to the client.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
